### PR TITLE
Features/update sql checker include cfc

### DIFF
--- a/lib/rules/SQLChecker.cfc
+++ b/lib/rules/SQLChecker.cfc
@@ -14,7 +14,7 @@ component extends="../BaseRule" {
         variables.message = "Found SQL query and related variables in code";
         variables.group = "OptionalRules";
         variables.enabled = false;
-        variables.nodeTypes = "CFMLTag,CallExpression,AssignmentExpression"
+        //variables.nodeTypes = "CFMLTag,CallExpression,AssignmentExpression"
 
 
         variables.parameters = {

--- a/lib/rules/SQLChecker.cfc
+++ b/lib/rules/SQLChecker.cfc
@@ -14,11 +14,11 @@ component extends="../BaseRule" {
         variables.message = "Found SQL query and related variables in code";
         variables.group = "OptionalRules";
         variables.enabled = false;
-        // variables.nodeTypes = "CFMLTag,CallExpression,AssignmentExpression"
+        variables.nodeTypes = "CFMLTag,CallExpression,AssignmentExpression"
 
 
         variables.parameters = {
-            "extensions": "cfm,cfml"
+            "extensions": "cfc,cfm,cfml"
         };
 
         return this;
@@ -34,13 +34,17 @@ component extends="../BaseRule" {
                             (node.type == "CFMLTag" && node.name == "query") //Query Tags
                             OR (node.type == "CallExpression"  //queryExecute
                             AND node?.callee?.type == "Identifier" 
-                            AND node?.callee?.name == "queryExecute")
+                            AND compareNoCase(node?.callee?.name ?: "", "queryExecute") == 0)
+                            OR (node.type == "AssignmentExpression" // var result = queryExecute(...)
+                                AND node?.right?.type == "CallExpression"
+                                AND node?.right?.callee?.type == "Identifier"
+                                AND compareNoCase(node?.right?.callee?.name ?: "", "queryExecute") == 0)
                         );
     
         // More complex check for Query object creation
         if( node.type == "AssignmentExpression" && node?.right?.type == "CallExpression" &&
             node?.right?.isBuiltIn == true &&
-            node?.right?.callee?.name == "_createcomponent"
+            compareNoCase(node?.right?.callee?.name ?: "", "_createcomponent") == 0
         ){
             var suspectedQueryComponentArguments = node?.right?.arguments;
             var foundQuery = suspectedQueryComponentArguments.filter(

--- a/tests/specs/UnitTestChecker/UnitTestCheckerTest.cfc
+++ b/tests/specs/UnitTestChecker/UnitTestCheckerTest.cfc
@@ -35,7 +35,7 @@ component extends="testbox.system.BaseSpec"{
                 // Test with a source file that does NOT have a corresponding test
                 var ret = module.main(
                     file = "../artefacts/components/com/myapp/utils/Helper.cfc",
-                    format = "silent",
+                    format = "raw",
                     rules = "UNIT_TEST_CHECK"
                 );
 
@@ -53,7 +53,7 @@ component extends="testbox.system.BaseSpec"{
                 // Test with a test file that does NOT have a corresponding source
                 var ret = module.main(
                     file = "../artefacts/unit_tests/testcases/com/myapp/orphan/OrphanTest.cfc",
-                    format = "silent",
+                    format = "raw",
                     rules = "UNIT_TEST_CHECK"
                 );
 
@@ -71,7 +71,7 @@ component extends="testbox.system.BaseSpec"{
                 // Test with a file that doesn't match the unit test regex pattern
                 var ret = module.main(
                     file = "../artefacts/queries.cfm",
-                    format = "silent",
+                    format = "raw",
                     rules = "UNIT_TEST_CHECK"
                 );
 

--- a/tests/specs/artefacts/components/com/myapp/services/SampleService.cfc
+++ b/tests/specs/artefacts/components/com/myapp/services/SampleService.cfc
@@ -13,4 +13,16 @@ component {
         return "Processed: " & input;
     }
 
+    public function getData(required array data) {
+        if (arrayLen(arguments.data) == 0) {
+            return [];
+        }
+        var queryResult = queryExecute(
+            sql: "
+                select * from customers;
+            "
+        );
+        return valueArray(queryResult);
+    }
+
 }

--- a/tests/specs/lib/rules/SQLCheckerTest.cfc
+++ b/tests/specs/lib/rules/SQLCheckerTest.cfc
@@ -33,14 +33,29 @@ component extends="testbox.system.BaseSpec"{
     
                 debug(module);
             it( "should find all sql variables in a page", () => {
-                var ret = module.main(file="../../artefacts/queries.cfm", format="raw", rules="SQL_CHECK", silent=true);
+                var ret = module.main(file="../../artefacts/queries.cfm", format="raw", rules="SQL_CHECK");
                 debug(ret);
                 expect( ret ).toBeArray( );
-                expect( ret.len() ).toBe( 24 );
+                expect( ret.len() ).toBe( 25 );
 
                 var firstIssue = ret[1];
                 expect( firstIssue.getRuleCode() ).toBe( "SQL_CHECK" );
                 expect( firstIssue.getCode() ).toBe( 'qry = new Query("SELECT * FROM ELVIS")' );
+            } )
+
+            it( "should find all sql variables in a CFC file", () => {
+                var ret = module.main(file="../../artefacts/components/com/myapp/services/SampleService.cfc", format="raw", rules="SQL_CHECK");
+                debug(ret);
+                expect( ret ).toBeArray( );
+                expect( ret.len() ).toBe( 1 );
+
+                var firstIssue = ret[1];
+                expect( firstIssue.getRuleCode() ).toBe( "SQL_CHECK" );
+                expect( firstIssue.getCode() ).toBe( 'var queryResult = queryExecute(
+            sql: "
+                select * from customers;
+            "
+        )' );
             } )
 
         } )

--- a/tests/specs/lib/rules/SQLCheckerTest.cfc
+++ b/tests/specs/lib/rules/SQLCheckerTest.cfc
@@ -33,7 +33,7 @@ component extends="testbox.system.BaseSpec"{
     
                 debug(module);
             it( "should find all sql variables in a page", () => {
-                var ret = module.main(file="../../artefacts/queries.cfm", format="raw", rules="SQL_CHECK");
+                var ret = module.main(file="../../artefacts/queries.cfm", format="raw", rules="SQL_CHECK", silent=true);
                 debug(ret);
                 expect( ret ).toBeArray( );
                 expect( ret.len() ).toBe( 25 );
@@ -44,7 +44,7 @@ component extends="testbox.system.BaseSpec"{
             } )
 
             it( "should find all sql variables in a CFC file", () => {
-                var ret = module.main(file="../../artefacts/components/com/myapp/services/SampleService.cfc", format="raw", rules="SQL_CHECK");
+                var ret = module.main(file="../../artefacts/components/com/myapp/services/SampleService.cfc", format="raw", rules="SQL_CHECK", silent=true);
                 debug(ret);
                 expect( ret ).toBeArray( );
                 expect( ret.len() ).toBe( 1 );


### PR DESCRIPTION
Adds cfc as a default extension to be checked for sql
Makes the string comparison "queryExecute" case-insensitive
Change output format for UnitTestCheckerTest to "raw" so that tests pass