### PR TITLE
Feature/sql check edge cases

### DIFF
--- a/lib/CFMLLinter.cfc
+++ b/lib/CFMLLinter.cfc
@@ -340,6 +340,7 @@ component accessors="true" {
     {
         var results = []
         node.type = node.type ?: "";
+
         for(var rule in arguments.allrules){
             var ruleItem = "Rule: #rule#"; 
             var ruleObj = arguments.allrules[rule];
@@ -385,6 +386,18 @@ component accessors="true" {
 
             // variables.timer.stop(ruleItem);
             results.append(ruleResults, true);
+        }
+
+        if(StructKeyExists(node, "argument") && isStruct(node.argument)){
+            var argument_results = recursiveNodeParser(
+                node: node.argument,
+                document: arguments.document,
+                fileName: arguments.fileName,
+                fileContent: fileContent,
+                helper: arguments.helper,
+                allrules: arguments.allrules
+                );
+            results.append(argument_results, true);
         }
 
         if(!StructKeyExists(node, "body")){

--- a/lib/CFMLLinter.cfc
+++ b/lib/CFMLLinter.cfc
@@ -55,6 +55,11 @@ component accessors="true" {
             return lintResults;
         }
         catch(e){
+            if(isUndefinedTagParseError(e)){
+                var ast = astFromPathWithUndefinedTagFallback(arguments.filePath, e);
+                var lintResults = lintAST(ast, arguments.filePath);
+                return lintResults;
+            }
             if(variables.ruleConfiguration.getGlobalSetting("ignoreParseErrors", false)){
                 return [];
             }
@@ -87,6 +92,109 @@ component accessors="true" {
             ];
         }
         // Parse the file using Lucee's AST parser
+    }
+
+    private struct function astFromPathWithUndefinedTagFallback(required string filePath, required any originalError) {
+        var fileContent = fileRead(arguments.filePath);
+        var parseError = arguments.originalError;
+        var sanitizedTags = [];
+
+        for(var attempt = 1; attempt <= 10; attempt++){
+            var tagName = getUndefinedTagName(parseError.message ?: "");
+            if(!len(tagName)){
+                throw(type=parseError.type ?: "ParseError", message=parseError.message ?: "Unable to parse file", detail=parseError.detail ?: "");
+            }
+
+            var sanitizedContent = replaceUndefinedTagWithCfIf(fileContent, tagName);
+            if(sanitizedContent == fileContent){
+                throw(type=parseError.type ?: "ParseError", message=parseError.message ?: "Unable to parse file", detail=parseError.detail ?: "");
+            }
+
+            fileContent = sanitizedContent;
+            sanitizedTags.append(tagName);
+
+            try {
+                return astFromString(fileContent);
+            }
+            catch(any retryError) {
+                if(!isUndefinedTagParseError(retryError)){
+                    throw(type=retryError.type ?: "ParseError", message=retryError.message ?: "Unable to parse file", detail=retryError.detail ?: "");
+                }
+                parseError = retryError;
+            }
+        }
+
+        throw(type="ParseFallbackLimit", message="Unable to parse after sanitizing undefined tags: " & arrayToList(sanitizedTags));
+    }
+
+    private boolean function isUndefinedTagParseError(required any error) {
+        return findNoCase("undefined tag [", arguments.error.message ?: "") > 0;
+    }
+
+    private string function getUndefinedTagName(required string message) {
+        var marker = "undefined tag [";
+        var startAt = findNoCase(marker, arguments.message);
+        if(!startAt){
+            return "";
+        }
+
+        startAt += len(marker);
+        var endAt = find("]", arguments.message, startAt);
+        if(!endAt){
+            return "";
+        }
+
+        return mid(arguments.message, startAt, endAt - startAt);
+    }
+
+    private string function replaceUndefinedTagWithCfIf(required string fileContent, required string tagName) {
+        var lt = chr(60);
+        var gt = chr(62);
+        var sanitized = replaceTagMatchesPreservingLength(
+            content: arguments.fileContent,
+            pattern: lt & arguments.tagName & "(\s|" & gt & "|/)[^" & gt & "]*" & gt,
+            replacementPrefix: lt & "cfif true"
+        );
+
+        sanitized = replaceTagMatchesPreservingLength(
+            content: sanitized,
+            pattern: lt & "/" & arguments.tagName & "\s*" & gt,
+            replacementPrefix: lt & "/cfif"
+        );
+
+        return sanitized;
+    }
+
+    private string function replaceTagMatchesPreservingLength(
+        required string content,
+        required string pattern,
+        required string replacementPrefix
+    ) {
+        var output = arguments.content;
+        var startAt = 1;
+        var match = reFindNoCase(arguments.pattern, output, startAt, true);
+
+        while(arrayLen(match.pos) && match.pos[1] > 0){
+            var matchText = mid(output, match.pos[1], match.len[1]);
+            var replacement = makePaddedTagReplacement(matchText, arguments.replacementPrefix);
+            var prefix = match.pos[1] > 1 ? left(output, match.pos[1] - 1) : "";
+            output = prefix & replacement & mid(output, match.pos[1] + match.len[1]);
+            startAt = match.pos[1] + match.len[1];
+            match = reFindNoCase(arguments.pattern, output, startAt, true);
+        }
+
+        return output;
+    }
+
+    private string function makePaddedTagReplacement(required string matchText, required string replacementPrefix) {
+        var totalLength = len(arguments.matchText);
+        var paddingLength = totalLength - len(arguments.replacementPrefix) - 1;
+
+        if(paddingLength < 0){
+            return arguments.matchText;
+        }
+
+        return arguments.replacementPrefix & repeatString(" ", paddingLength) & ">";
     }
     /**
      * Lint all CFML files in a folder (recursively)

--- a/lib/rules/SQLChecker.cfc
+++ b/lib/rules/SQLChecker.cfc
@@ -39,6 +39,9 @@ component extends="../BaseRule" {
                                 AND node?.right?.callee?.type == "Identifier"
                                 AND compareNoCase(node?.right?.callee?.name ?: "", "queryExecute") == 0)
                         );
+
+        var ext = listLast(fileName, ".");
+        var extensionAllowed = listFindNoCase( variables.parameters.extensions, ext ) > 0;
     
         // More complex check for Query object creation
         if( node.type == "AssignmentExpression" && node?.right?.type == "CallExpression" &&
@@ -62,8 +65,7 @@ component extends="../BaseRule" {
         }
         
         // Check the extensions
-        var ext = listLast(fileName, ".");
-        if( not listFindNoCase( variables.parameters.extensions, ext ) ){
+        if( not extensionAllowed ){
             return results;
         }
         

--- a/tests/specs/artefacts/components/com/myapp/services/ReturnQueryExecuteService.cfc
+++ b/tests/specs/artefacts/components/com/myapp/services/ReturnQueryExecuteService.cfc
@@ -1,0 +1,14 @@
+/**
+ * Fixture for queryExecute calls returned directly from a function.
+ */
+component {
+
+    public query function getUsers() {
+        return queryExecute(
+            sql: "
+                SELECT id
+                FROM users
+            "
+        );
+    }
+}

--- a/tests/specs/artefacts/customTagWrappedQuery.cfm
+++ b/tests/specs/artefacts/customTagWrappedQuery.cfm
@@ -1,0 +1,6 @@
+<cfUnknownWrapper name="example">
+    <cfquery name="wrappedQuery">
+        SELECT id
+        FROM users
+    </cfquery>
+</cfUnknownWrapper>

--- a/tests/specs/lib/rules/SQLCheckerTest.cfc
+++ b/tests/specs/lib/rules/SQLCheckerTest.cfc
@@ -58,6 +58,15 @@ component extends="testbox.system.BaseSpec"{
         )' );
             } )
 
+            it( "should find SQL inside an unknown custom tag wrapper", () => {
+                var ret = module.main(file="../../artefacts/customTagWrappedQuery.cfm", format="raw", rules="SQL_CHECK", silent=true);
+
+                expect( ret ).toBeArray();
+                expect( ret.len() ).toBe( 1 );
+                expect( ret[1].getRuleCode() ).toBe( "SQL_CHECK" );
+                expect( ret[1].getCode() ).toInclude( "SELECT id" );
+            } )
+
         } )
     }
 

--- a/tests/specs/lib/rules/SQLCheckerTest.cfc
+++ b/tests/specs/lib/rules/SQLCheckerTest.cfc
@@ -67,6 +67,16 @@ component extends="testbox.system.BaseSpec"{
                 expect( ret[1].getCode() ).toInclude( "SELECT id" );
             } )
 
+            it( "should find queryExecute returned directly from a function", () => {
+                var ret = module.main(file="../../artefacts/components/com/myapp/services/ReturnQueryExecuteService.cfc", format="raw", rules="SQL_CHECK", silent=true);
+
+                expect( ret ).toBeArray();
+                expect( ret.len() ).toBe( 1 );
+                expect( ret[1].getRuleCode() ).toBe( "SQL_CHECK" );
+                expect( ret[1].getLine() ).toBe( 7 );
+                expect( ret[1].getCode() ).toInclude( "queryExecute" );
+            } )
+
         } )
     }
 


### PR DESCRIPTION
This adds additional parsing logic for some edge cases I found. Particularly when an unknown custom CFML tag is found, or "return queryExecute(...)" is used